### PR TITLE
Fixed the issue in the example code 

### DIFF
--- a/examples/SimpleAudioPlayer/SimpleAudioPlayer.ino
+++ b/examples/SimpleAudioPlayer/SimpleAudioPlayer.ino
@@ -38,7 +38,7 @@ void setup() {
 
   // 44100kHz stereo => 88200 sample rate
   // 100 mSec of prebuffering.
-  Audio.begin(88200, 100);
+  //Audio.begin(88200, 100);
 }
 
 void loop() {
@@ -46,6 +46,7 @@ void loop() {
 
   // open wave file from sdcard
   File myFile = SD.open("test.wav");
+  Audio.begin(88200, 100); 
   if (!myFile) {
     // if the file didn't open, print an error and stop
     Serial.println("error opening test.wav");
@@ -75,7 +76,7 @@ void loop() {
     }
   }
   myFile.close();
-
+  Audio.close();
   Serial.println("End of file. Thank you for listening!");
   while (true) ;
 }

--- a/examples/SimpleAudioPlayer/SimpleAudioPlayer.ino
+++ b/examples/SimpleAudioPlayer/SimpleAudioPlayer.ino
@@ -38,7 +38,6 @@ void setup() {
 
   // 44100kHz stereo => 88200 sample rate
   // 100 mSec of prebuffering.
-  //Audio.begin(88200, 100);
 }
 
 void loop() {
@@ -80,4 +79,3 @@ void loop() {
   Serial.println("End of file. Thank you for listening!");
   while (true) ;
 }
-


### PR DESCRIPTION
Fixed the issue in the example code wherein if you play an audio multiple times, it gets distorted over time. I was facing a very similar issue as mentioned in:
https://github.com/arduino-libraries/Audio/issues/1 

Removing the Audio.begin() from the setup and adding it right after the file.open() and adding Audio.end() towards the end solved the issue for me. 

