### PR TITLE
Correct units in example sketch comment

### DIFF
--- a/examples/SimpleAudioPlayer/SimpleAudioPlayer.ino
+++ b/examples/SimpleAudioPlayer/SimpleAudioPlayer.ino
@@ -36,7 +36,7 @@ void setup() {
   Serial.println(" done.");
   // hi-speed SPI transfers
 
-  // 44100kHz stereo => 88200 sample rate
+  // 44100 Hz stereo => 88200 Hz sample rate
   // 100 mSec of prebuffering.
   Audio.begin(88200, 100);
 }


### PR DESCRIPTION
The  comment used kHz in place of Hz.

---
Related to (but doesn't fix) https://github.com/arduino/Arduino/issues/10800